### PR TITLE
FIX: Cannot install via Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,5 +41,8 @@ RUN \
 
 # copy binaries
 RUN cp fastText/fasttext fasttext.js/lib/bin/linux/
+
+# run train
+RUN node fasttext.js/examples/train.js
     
 CMD ["bash"]


### PR DESCRIPTION
### Issue
#9 Cannot install via Docker due to no train data

### Done
Add train script in Dockerfile