### PR TITLE
Fix win32 platform fasttext executable name

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -105,6 +105,9 @@
     var Util = {
 
         GetBinFolder: function (filename) {
+            if (process.platform === 'win32') {
+                filename = filename + '.exe';
+            }
             var cdir = process.cwd();
             var pathComponents = __dirname.split(path.sep);
             var root = pathComponents.slice(0, pathComponents.length).join(path.sep);
@@ -175,7 +178,7 @@
         },//getUUID
 
         /*
-        * Recursively merge properties of two objects 
+        * Recursively merge properties of two objects
         * @todo: moved to Util
         */
         mergeRecursive: function (obj1, obj2) {
@@ -334,7 +337,7 @@
         },//getTextLinesNormalized
 
         /**
-         * Remove all punctations, control chars, diacritics from text 
+         * Remove all punctations, control chars, diacritics from text
          * it supports latin1 and unicode charset
          */
         removeAllPunctations: function (text, newline = ' ', diacritics = true, lower = true, latin = true, punct = true) {


### PR DESCRIPTION
This should fix https://github.com/loretoparisi/fasttext.js/issues/22

@loretoparisi please take a look and let me know if there's any other things needed

tests were conducted preliminarily through running `node .\examples\test.js`, and the direct invocation of the `Util.GetBinFolder` function:

```js
> Util.GetBinFolder('fasttext')
'C:\\Users\\woozyking\\proj\\fasttext.js\\lib\\bin\\win32\\fasttext.exe'
```

since Windows FS isn't strict about lettercases, althought it should have been strictly `fastText.exe`, this still works