### PR TITLE
Fix $ROOT in confusion.sh

### DIFF
--- a/tools/confusion.sh
+++ b/tools/confusion.sh
@@ -16,7 +16,7 @@ PLATFORM=$(uname)
 
 if [[ "$PLATFORM" == 'Linux' ]]; then
    BIN=../lib/bin/linux/fasttext
-   ROOT="{${TMPDIR:-$(dirname $(mktemp))/}"
+   ROOT="${TMPDIR:-$(dirname $(mktemp))/}"
 elif [[ "$PLATFORM" == 'Darwin' ]]; then
    BIN=../lib/bin/darwin/fasttext
    ROOT=$TMPDIR


### PR DESCRIPTION
Leading `{` caused bad file path:
```
Normalizing dataset ../examples/dataset/sms.tsv...
./confusion.sh: line 37: {/tmp/norm: No such file or directory
```